### PR TITLE
Better multi interface support

### DIFF
--- a/src/api/upnpapi.cpp
+++ b/src/api/upnpapi.cpp
@@ -809,6 +809,33 @@ EXPORT_SPEC int UpnpSetHostValidateCallback(
     return UpnpSetWebRequestHostValidateCallback(callback, cookie);
 }
 
+EXPORT_SPEC unsigned short UpnpGetServerPort()
+{
+    if (UpnpSdkInit != 1)
+        return 0U;
+
+    return LOCAL_PORT_V4;
+}
+
+EXPORT_SPEC unsigned short UpnpGetServerPort6()
+{
+#ifdef UPNP_ENABLE_IPV6
+    if (UpnpSdkInit != 1)
+        return 0U;
+
+    return LOCAL_PORT_V6;
+#else
+    return 0;
+#endif
+}
+EXPORT_SPEC unsigned short UpnpGetServerUlaGuaPort6()
+{
+#ifdef UPNP_ENABLE_IPV6
+    return 0;
+#else
+    return 0;
+#endif
+}
 
 EXPORT_SPEC std::string UpnpGetUrlHostPortForClient(const struct sockaddr_storage* clsock)
 {
@@ -833,34 +860,6 @@ EXPORT_SPEC std::string UpnpGetUrlHostPortForClient(const struct sockaddr_storag
     }
 
     return prefix + hostaddr.straddr() + (prefix.empty() ? "" : "]") + ":" + lltodecstr(port);
-}
-
-EXPORT_SPEC unsigned short UpnpGetServerPort()
-{
-    if (UpnpSdkInit != 1)
-        return 0U;
-
-    return LOCAL_PORT_V4;
-}
-
-EXPORT_SPEC unsigned short UpnpGetServerPort6()
-{
-#ifdef UPNP_ENABLE_IPV6
-    if (UpnpSdkInit != 1)
-        return 0U;
-
-    return LOCAL_PORT_V6;
-#else
-    return 0;
-#endif
-}
-EXPORT_SPEC unsigned short UpnpGetServerUlaGuaPort6()
-{
-#ifdef UPNP_ENABLE_IPV6
-        return 0;
-#else
-        return 0;
-#endif
 }
 
 EXPORT_SPEC const char *UpnpGetServerIpAddress()

--- a/src/inc/miniserver.h
+++ b/src/inc/miniserver.h
@@ -38,6 +38,7 @@
 
 #include "httputils.h"
 #include "upnpinet.h"
+#include <vector>
 
 struct MiniServerSockArray {
     /*! Socket for stopping miniserver */
@@ -54,8 +55,12 @@ struct MiniServerSockArray {
     uint16_t miniServerPort6{0};
 #ifdef INCLUDE_CLIENT_APIS
     /*! SSDP sockets for sending search requests and receiving search replies */
-    SOCKET ssdpReqSock4{INVALID_SOCKET};
-    SOCKET ssdpReqSock6{INVALID_SOCKET};
+    std::vector<SOCKET> ssdpReqSock4List {};
+
+#ifdef UPNP_ENABLE_IPV6
+    std::vector<SOCKET> ssdpReqSock6List {};
+#endif /* UPNP_ENABLE_IPV6 */
+
 #endif /* INCLUDE_CLIENT_APIS */
 
     MiniServerSockArray() = default;
@@ -65,8 +70,12 @@ struct MiniServerSockArray {
         maybeClose(ssdpSock6);
         maybeClose(ssdpSock6UlaGua);
 #ifdef INCLUDE_CLIENT_APIS
-        maybeClose(ssdpReqSock4);
-        maybeClose(ssdpReqSock6);
+        for (SOCKET socket:ssdpReqSock4List) { maybeClose(socket); }
+
+#ifdef UPNP_ENABLE_IPV6
+        for (SOCKET socket:ssdpReqSock6List) { maybeClose(socket); }
+#endif /* UPNP_ENABLE_IPV6 */
+
 #endif /* INCLUDE_CLIENT_APIS */
     }
 

--- a/src/inc/ssdplib.h
+++ b/src/inc/ssdplib.h
@@ -39,6 +39,7 @@
 #include "upnpinet.h"
 
 #include <string>
+#include <vector>
 
 /* Standard defined values for the UPnP multicast addresses */
 #define SSDP_IP   "239.255.255.250"
@@ -105,9 +106,9 @@ struct SsdpEntity {
 
 /* Globals */
 #ifdef INCLUDE_CLIENT_APIS
-extern SOCKET gSsdpReqSocket4;
+extern std::vector<SOCKET> gSsdpReqSocket4List;
 #ifdef UPNP_ENABLE_IPV6
-extern SOCKET gSsdpReqSocket6;
+extern std::vector<SOCKET> gSsdpReqSocket6List;
 #endif /* UPNP_ENABLE_IPV6 */
 #endif /* INCLUDE_CLIENT_APIS */
 

--- a/src/ssdp/ssdp_ctrlpt.cpp
+++ b/src/ssdp/ssdp_ctrlpt.cpp
@@ -462,10 +462,6 @@ int SearchByTarget(int Mx, const char *St, const char *saddress, int port, void 
         if (retVal != UPNP_E_SUCCESS)
             return retVal;
     }
-#else
-    if (needv6) {
-        return UPNP_E_INVALID_PARAM;
-    }
 #endif
 
     /* Add the search criteria and callback to the list and schedule a timeout event to remove


### PR DESCRIPTION
La modification a été testée pour windows x86 et x64 avec l'ipv6 désactivée.
L'ipv6 reste à tester.
J'ai ajouté une fonction GetLastError() cross plateforme qui récupère la description associée au code d'erreur dans ssdp_ctrlpt.cpp. Il pourrait être intéréssant de la déplacer dans une classe utilitaire.

La lib permet maintenant de détecter correctement un device sur toutes les interfaces intialisées et pas uniquement sur la première. Dans le cas où une interface est désactivée puis réactivée, la socket d'envoi associée peut se retrouver dans un état invalide. Dans l'idéal il faudrait monitorer les changements d'état sur les interfaces puis recréer la socket associée en cas de changement (changement d'ip, ou d'état). Je ne me suis pas lancé dans cette modification et j'ai pris le partit de gérer ça en dehors de la lib en la reinitialisant complètement en cas de changement.